### PR TITLE
fix/issue-1: added css prop to remove error on multiple button clicks

### DIFF
--- a/styles/button.css
+++ b/styles/button.css
@@ -209,6 +209,10 @@
     display: none;
 }
 
+.button.animate {
+    pointer-events: none;
+}
+
 .button.animate .process-loading {
     display: block;
 }


### PR DESCRIPTION
Added `pointer-events: none` property to the `.animate` class so that we can't reset the animation on multiple clicks.